### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.2"
 edition = "2021"
 description = "an unnecessarily fast nbt decoder"
 license = "MIT"
+repository = "https://github.com/mat-1/simdnbt"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
to allow crates.io, rust-digger, and others to link to it