### PR TITLE
Optimize simdnbt::borrow and probably introduce UB

### DIFF
--- a/simdnbt/README.md
+++ b/simdnbt/README.md
@@ -87,11 +87,12 @@ Here's a benchmark comparing Simdnbt against a few of the other fastest NBT crat
 | [hematite_nbt](https://docs.rs/hematite-nbt/latest/nbt/)                    | 108.91 MiB/s |
 
 And for writing `complex_player.dat`:
-| Library | Throughput |
-| ----------------| ------------ |
+
+| Library         | Throughput   |
+| --------------- | ------------ |
 | simdnbt::borrow | 2.5914 GiB/s |
-| azalea_nbt | 2.1096 GiB/s |
-| simdnbt::owned | 1.9508 GiB/s |
+| azalea_nbt      | 2.1096 GiB/s |
+| simdnbt::owned  | 1.9508 GiB/s |
 | graphite_binary | 1.7745 GiB/s |
 
 The tables above were made from the [compare benchmark](https://github.com/azalea-rs/simdnbt/tree/master/simdnbt/benches) in this repo.

--- a/simdnbt/README.md
+++ b/simdnbt/README.md
@@ -60,10 +60,12 @@ The most significant and simple optimization you can do is switching to an alloc
 ## Implementation details
 
 Simdnbt currently makes use of SIMD instructions for two things:
-- swapping the endianness of int arrays
-- checking if a string is plain ascii for faster mutf8 to utf8 conversion
+
+-   swapping the endianness of int arrays
+-   checking if a string is plain ascii for faster mutf8 to utf8 conversion
 
 Simdnbt ~~cheats~~ takes some shortcuts to be this fast:
+
 1. it requires a reference to the original data (to avoid cloning)
 2. it doesn't validate/decode the mutf-8 strings at decode-time
 
@@ -75,7 +77,7 @@ Here's a benchmark comparing Simdnbt against a few of the other fastest NBT crat
 
 | Library                                                                     | Throughput   |
 | --------------------------------------------------------------------------- | ------------ |
-| [simdnbt::borrow](https://docs.rs/simdnbt/latest/simdnbt/borrow/index.html) | 717.45 MiB/s |
+| [simdnbt::borrow](https://docs.rs/simdnbt/latest/simdnbt/borrow/index.html) | 1.0900 GiB/s |
 | [simdnbt::owned](https://docs.rs/simdnbt/latest/simdnbt/owned/index.html)   | 329.10 MiB/s |
 | [shen_nbt5](https://docs.rs/shen-nbt5/latest/shen_nbt5/)                    | 306.58 MiB/s |
 | [azalea_nbt](https://docs.rs/azalea-nbt/latest/azalea_nbt/)                 | 297.28 MiB/s |
@@ -85,13 +87,12 @@ Here's a benchmark comparing Simdnbt against a few of the other fastest NBT crat
 | [hematite_nbt](https://docs.rs/hematite-nbt/latest/nbt/)                    | 108.91 MiB/s |
 
 And for writing `complex_player.dat`:
-| Library         | Throughput   |
+| Library | Throughput |
 | ----------------| ------------ |
 | simdnbt::borrow | 2.5914 GiB/s |
-| azalea_nbt      | 2.1096 GiB/s |
-| simdnbt::owned  | 1.9508 GiB/s |
+| azalea_nbt | 2.1096 GiB/s |
+| simdnbt::owned | 1.9508 GiB/s |
 | graphite_binary | 1.7745 GiB/s |
-
 
 The tables above were made from the [compare benchmark](https://github.com/azalea-rs/simdnbt/tree/master/simdnbt/benches) in this repo.
 Note that the benchmark is somewhat unfair, since `simdnbt::borrow` doesn't fully decode some things like strings and integer arrays until they're used.

--- a/simdnbt/README.md
+++ b/simdnbt/README.md
@@ -77,7 +77,7 @@ Here's a benchmark comparing Simdnbt against a few of the other fastest NBT crat
 
 | Library                                                                     | Throughput   |
 | --------------------------------------------------------------------------- | ------------ |
-| [simdnbt::borrow](https://docs.rs/simdnbt/latest/simdnbt/borrow/index.html) | 1.0900 GiB/s |
+| [simdnbt::borrow](https://docs.rs/simdnbt/latest/simdnbt/borrow/index.html) | 1.7619 GiB/s |
 | [simdnbt::owned](https://docs.rs/simdnbt/latest/simdnbt/owned/index.html)   | 329.10 MiB/s |
 | [shen_nbt5](https://docs.rs/shen-nbt5/latest/shen_nbt5/)                    | 306.58 MiB/s |
 | [azalea_nbt](https://docs.rs/azalea-nbt/latest/azalea_nbt/)                 | 297.28 MiB/s |

--- a/simdnbt/benches/compare.rs
+++ b/simdnbt/benches/compare.rs
@@ -138,9 +138,9 @@ fn bench(c: &mut Criterion) {
     // bench_read_file("hello_world.nbt", c);
     // bench_read_file("bigtest.nbt", c);
     // bench_read_file("simple_player.dat", c);
-    // bench_read_file("complex_player.dat", c);
+    bench_read_file("complex_player.dat", c);
     // bench_read_file("level.dat", c);
-    bench_read_file("inttest1023.nbt", c);
+    // bench_read_file("inttest1023.nbt", c);
 }
 
 criterion_group!(compare, bench);

--- a/simdnbt/benches/nbt.rs
+++ b/simdnbt/benches/nbt.rs
@@ -50,10 +50,11 @@ fn bench_file(filename: &str, c: &mut Criterion) {
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 fn bench(c: &mut Criterion) {
-    // bench_file("bigtest.nbt", c);
-    // bench_file("simple_player.dat", c);
+    bench_file("bigtest.nbt", c);
+    bench_file("simple_player.dat", c);
     bench_file("complex_player.dat", c);
-    // bench_file("level.dat", c);
+    bench_file("level.dat", c);
+
     // bench_file("stringtest.nbt", c);
     // bench_file("inttest16.nbt", c);
 

--- a/simdnbt/src/borrow/compound.rs
+++ b/simdnbt/src/borrow/compound.rs
@@ -18,7 +18,7 @@ pub struct NbtCompound<'a> {
     values: &'a [(&'a Mutf8Str, NbtTag<'a>)],
 }
 
-impl<'a, 'b> NbtCompound<'a> {
+impl<'a> NbtCompound<'a> {
     pub fn read(
         data: &mut Cursor<&'a [u8]>,
         alloc: &UnsafeCell<TagAllocator<'a>>,
@@ -37,7 +37,7 @@ impl<'a, 'b> NbtCompound<'a> {
 
         let alloc_mut = unsafe { alloc.get().as_mut().unwrap() };
 
-        let mut tags = alloc_mut.start_compound(depth);
+        let mut tags = alloc_mut.start_named_tags(depth);
         loop {
             let tag_type = data.read_u8().map_err(|_| Error::UnexpectedEof)?;
             if tag_type == END_ID {
@@ -45,13 +45,13 @@ impl<'a, 'b> NbtCompound<'a> {
             }
             let tag_name = read_string(data)?;
 
-            tags.push(
+            tags.push((
                 tag_name,
                 NbtTag::read_with_type(data, alloc, tag_type, depth)?,
-            );
+            ));
         }
         let alloc_mut = unsafe { alloc.get().as_mut().unwrap() };
-        let values = alloc_mut.finish_compound(tags);
+        let values = alloc_mut.finish_named_tags(tags, depth);
 
         Ok(Self { values })
     }

--- a/simdnbt/src/borrow/list.rs
+++ b/simdnbt/src/borrow/list.rs
@@ -80,7 +80,14 @@ impl<'a> NbtList<'a> {
                 let alloc_mut = unsafe { alloc.get().as_mut().unwrap() };
                 let mut tags = alloc_mut.start_unnamed_list_tags(depth);
                 for _ in 0..length {
-                    tags.push(NbtList::read(data, alloc, depth + 1)?)
+                    let tag = match NbtList::read(data, alloc, depth + 1) {
+                        Ok(tag) => tag,
+                        Err(e) => {
+                            alloc_mut.finish_unnamed_list_tags(tags, depth);
+                            return Err(e);
+                        }
+                    };
+                    tags.push(tag)
                 }
                 let alloc_mut = unsafe { alloc.get().as_mut().unwrap() };
                 alloc_mut.finish_unnamed_list_tags(tags, depth)
@@ -92,7 +99,14 @@ impl<'a> NbtList<'a> {
                 let alloc_mut = unsafe { alloc.get().as_mut().unwrap() };
                 let mut tags = alloc_mut.start_unnamed_compound_tags(depth);
                 for _ in 0..length {
-                    tags.push(NbtCompound::read_with_depth(data, alloc, depth + 1)?)
+                    let tag = match NbtCompound::read_with_depth(data, alloc, depth + 1) {
+                        Ok(tag) => tag,
+                        Err(e) => {
+                            alloc_mut.finish_unnamed_compound_tags(tags, depth);
+                            return Err(e);
+                        }
+                    };
+                    tags.push(tag);
                 }
                 let alloc_mut = unsafe { alloc.get().as_mut().unwrap() };
                 alloc_mut.finish_unnamed_compound_tags(tags, depth)

--- a/simdnbt/src/borrow/list.rs
+++ b/simdnbt/src/borrow/list.rs
@@ -1,4 +1,4 @@
-use std::{cell::UnsafeCell, io::Cursor};
+use std::io::Cursor;
 
 use byteorder::ReadBytesExt;
 
@@ -37,7 +37,7 @@ pub enum NbtList<'a> {
 impl<'a> NbtList<'a> {
     pub fn read(
         data: &mut Cursor<&'a [u8]>,
-        alloc: &UnsafeCell<TagAllocator<'a>>,
+        alloc: &TagAllocator<'a>,
         depth: usize,
     ) -> Result<Self, Error> {
         if depth > MAX_DEPTH {
@@ -57,105 +57,93 @@ impl<'a> NbtList<'a> {
             DOUBLE_ID => NbtList::Double(RawList::new(read_with_u32_length(data, 8)?)),
             BYTE_ARRAY_ID => NbtList::ByteArray({
                 let length = read_u32(data)?;
-                let alloc_mut = unsafe { alloc.get().as_mut().unwrap() };
-                let mut tags = alloc_mut.unnamed_bytearray.start(depth);
+                let mut tags = alloc.get().unnamed_bytearray.start(depth);
                 for _ in 0..length {
                     let tag = match read_u8_array(data) {
                         Ok(tag) => tag,
                         Err(e) => {
-                            alloc_mut.unnamed_bytearray.finish(tags, depth);
+                            alloc.get().unnamed_bytearray.finish(tags, depth);
                             return Err(e);
                         }
                     };
                     tags.push(tag);
                 }
-                let alloc_mut = unsafe { alloc.get().as_mut().unwrap() };
-                alloc_mut.unnamed_bytearray.finish(tags, depth)
+                alloc.get().unnamed_bytearray.finish(tags, depth)
             }),
             STRING_ID => NbtList::String({
                 let length = read_u32(data)?;
-                let alloc_mut = unsafe { alloc.get().as_mut().unwrap() };
-                let mut tags = alloc_mut.unnamed_string.start(depth);
+                let mut tags = alloc.get().unnamed_string.start(depth);
                 for _ in 0..length {
                     let tag = match read_string(data) {
                         Ok(tag) => tag,
                         Err(e) => {
-                            alloc_mut.unnamed_string.finish(tags, depth);
+                            alloc.get().unnamed_string.finish(tags, depth);
                             return Err(e);
                         }
                     };
                     tags.push(tag);
                 }
-                let alloc_mut = unsafe { alloc.get().as_mut().unwrap() };
-                alloc_mut.unnamed_string.finish(tags, depth)
+                alloc.get().unnamed_string.finish(tags, depth)
             }),
             LIST_ID => NbtList::List({
                 let length = read_u32(data)?;
-                let alloc_mut = unsafe { alloc.get().as_mut().unwrap() };
-                let mut tags = alloc_mut.unnamed_list.start(depth);
+                let mut tags = alloc.get().unnamed_list.start(depth);
                 for _ in 0..length {
                     let tag = match NbtList::read(data, alloc, depth + 1) {
                         Ok(tag) => tag,
                         Err(e) => {
-                            alloc_mut.unnamed_list.finish(tags, depth);
+                            alloc.get().unnamed_list.finish(tags, depth);
                             return Err(e);
                         }
                     };
                     tags.push(tag)
                 }
-                let alloc_mut = unsafe { alloc.get().as_mut().unwrap() };
-                alloc_mut.unnamed_list.finish(tags, depth)
+                alloc.get().unnamed_list.finish(tags, depth)
             }),
             COMPOUND_ID => NbtList::Compound({
                 let length = read_u32(data)?;
-                let alloc_mut = unsafe { alloc.get().as_mut().unwrap() };
-                let mut tags = alloc_mut.unnamed_compound.start(depth);
+                let mut tags = alloc.get().unnamed_compound.start(depth);
                 for _ in 0..length {
                     let tag = match NbtCompound::read_with_depth(data, alloc, depth + 1) {
                         Ok(tag) => tag,
                         Err(e) => {
-                            alloc_mut.unnamed_compound.finish(tags, depth);
+                            alloc.get().unnamed_compound.finish(tags, depth);
                             return Err(e);
                         }
                     };
                     tags.push(tag);
                 }
-                let alloc_mut = unsafe { alloc.get().as_mut().unwrap() };
-                alloc_mut.unnamed_compound.finish(tags, depth)
+                alloc.get().unnamed_compound.finish(tags, depth)
             }),
             INT_ARRAY_ID => NbtList::IntArray({
                 let length = read_u32(data)?;
-                let alloc_mut = unsafe { alloc.get().as_mut().unwrap() };
-                let mut tags = alloc_mut.unnamed_intarray.start(depth);
+                let mut tags = alloc.get().unnamed_intarray.start(depth);
                 for _ in 0..length {
                     let tag = match read_int_array(data) {
                         Ok(tag) => tag,
                         Err(e) => {
-                            alloc_mut.unnamed_intarray.finish(tags, depth);
+                            alloc.get().unnamed_intarray.finish(tags, depth);
                             return Err(e);
                         }
                     };
                     tags.push(tag);
                 }
-                let alloc_mut = unsafe { alloc.get().as_mut().unwrap() };
-                alloc_mut.unnamed_intarray.finish(tags, depth)
+                alloc.get().unnamed_intarray.finish(tags, depth)
             }),
             LONG_ARRAY_ID => NbtList::LongArray({
                 let length = read_u32(data)?;
-                let alloc_mut = unsafe { alloc.get().as_mut().unwrap() };
-                let mut tags = alloc_mut.unnamed_longarray.start(depth);
+                let mut tags = alloc.get().unnamed_longarray.start(depth);
                 for _ in 0..length {
                     let tag = match read_long_array(data) {
                         Ok(tag) => tag,
                         Err(e) => {
-                            alloc_mut.unnamed_longarray.finish(tags, depth);
+                            alloc.get().unnamed_longarray.finish(tags, depth);
                             return Err(e);
                         }
                     };
                     tags.push(tag);
                 }
-                let alloc_mut = unsafe { alloc.get().as_mut().unwrap() };
-                alloc_mut.unnamed_longarray.finish(tags, depth)
+                alloc.get().unnamed_longarray.finish(tags, depth)
             }),
             _ => return Err(Error::UnknownTagId(tag_type)),
         })

--- a/simdnbt/src/borrow/mod.rs
+++ b/simdnbt/src/borrow/mod.rs
@@ -120,31 +120,39 @@ impl<'a> BaseNbt<'a> {
 }
 
 /// A single NBT tag.
-#[repr(u8)]
 #[derive(Debug, PartialEq, Clone)]
 pub enum NbtTag<'a> {
-    Byte(i8) = BYTE_ID,
-    Short(i16) = SHORT_ID,
-    Int(i32) = INT_ID,
-    Long(i64) = LONG_ID,
-    Float(f32) = FLOAT_ID,
-    Double(f64) = DOUBLE_ID,
-    ByteArray(&'a [u8]) = BYTE_ARRAY_ID,
-    String(&'a Mutf8Str) = STRING_ID,
-    List(NbtList<'a>) = LIST_ID,
-    Compound(NbtCompound<'a>) = COMPOUND_ID,
-    IntArray(RawList<'a, i32>) = INT_ARRAY_ID,
-    LongArray(RawList<'a, i64>) = LONG_ARRAY_ID,
+    Byte(i8),
+    Short(i16),
+    Int(i32),
+    Long(i64),
+    Float(f32),
+    Double(f64),
+    ByteArray(&'a [u8]),
+    String(&'a Mutf8Str),
+    List(NbtList<'a>),
+    Compound(NbtCompound<'a>),
+    IntArray(RawList<'a, i32>),
+    LongArray(RawList<'a, i64>),
 }
 impl<'a> NbtTag<'a> {
     /// Get the numerical ID of the tag type.
     #[inline]
     pub fn id(&self) -> u8 {
-        // SAFETY: Because `Self` is marked `repr(u8)`, its layout is a `repr(C)`
-        // `union` between `repr(C)` structs, each of which has the `u8`
-        // discriminant as its first field, so we can read the discriminant
-        // without offsetting the pointer.
-        unsafe { *<*const _>::from(self).cast::<u8>() }
+        match self {
+            NbtTag::Byte(_) => BYTE_ID,
+            NbtTag::Short(_) => SHORT_ID,
+            NbtTag::Int(_) => INT_ID,
+            NbtTag::Long(_) => LONG_ID,
+            NbtTag::Float(_) => FLOAT_ID,
+            NbtTag::Double(_) => DOUBLE_ID,
+            NbtTag::ByteArray(_) => BYTE_ARRAY_ID,
+            NbtTag::String(_) => STRING_ID,
+            NbtTag::List(_) => LIST_ID,
+            NbtTag::Compound(_) => COMPOUND_ID,
+            NbtTag::IntArray(_) => INT_ARRAY_ID,
+            NbtTag::LongArray(_) => LONG_ARRAY_ID,
+        }
     }
 
     fn read_with_type(

--- a/simdnbt/src/borrow/mod.rs
+++ b/simdnbt/src/borrow/mod.rs
@@ -155,6 +155,7 @@ impl<'a> NbtTag<'a> {
         }
     }
 
+    #[inline(always)]
     fn read_with_type(
         data: &mut Cursor<&'a [u8]>,
         alloc: &TagAllocator<'a>,

--- a/simdnbt/src/borrow/mod.rs
+++ b/simdnbt/src/borrow/mod.rs
@@ -26,7 +26,8 @@ pub use self::{compound::NbtCompound, list::NbtList};
 pub struct BaseNbt<'a> {
     name: &'a Mutf8Str,
     tag: NbtCompound<'a>,
-    tag_alloc: TagAllocator<'a>,
+    // we need to keep this around so it's not deallocated
+    _tag_alloc: TagAllocator<'a>,
 }
 
 #[derive(Debug, PartialEq, Default)]
@@ -54,7 +55,7 @@ impl<'a> Nbt<'a> {
         Ok(Nbt::Some(BaseNbt {
             name,
             tag,
-            tag_alloc: tag_alloc.into_inner(),
+            _tag_alloc: tag_alloc.into_inner(),
         }))
     }
 

--- a/simdnbt/src/borrow/tag_alloc.rs
+++ b/simdnbt/src/borrow/tag_alloc.rs
@@ -25,6 +25,7 @@ use crate::Mutf8Str;
 
 use super::{NbtCompound, NbtList, NbtTag};
 
+// this value appears to have the best results on my pc when testing with complex_player.dat
 const MIN_ALLOC_SIZE: usize = 1024;
 
 #[derive(Default)]

--- a/simdnbt/src/borrow/tag_alloc.rs
+++ b/simdnbt/src/borrow/tag_alloc.rs
@@ -232,6 +232,21 @@ impl<T> ContiguousTagsAllocator<T> {
     }
 
     #[inline]
+    pub fn extend_from_slice(&mut self, slice: &[T]) {
+        while self.alloc.len + slice.len() > self.alloc.cap {
+            self.grow();
+        }
+
+        // copy the slice
+        unsafe {
+            let end = self.alloc.ptr.as_ptr().add(self.alloc.len);
+            std::ptr::copy_nonoverlapping(slice.as_ptr(), end, slice.len());
+        }
+        self.alloc.len += slice.len();
+        self.size += slice.len();
+    }
+
+    #[inline]
     pub fn push(&mut self, value: T) {
         // check if we need to reallocate
         if self.alloc.len == self.alloc.cap {

--- a/simdnbt/src/borrow/tag_alloc.rs
+++ b/simdnbt/src/borrow/tag_alloc.rs
@@ -1,0 +1,318 @@
+//! Some tags, like compounds and arrays, contain other tags. The naive approach would be to just
+//! use `Vec`s or `HashMap`s, but this is inefficient and leads to many small allocations.
+//!
+//! Instead, the idea for this is essentially that we'd have two big Vec for every tag (one for
+//! named tags and one for unnamed tags), and then compounds/arrays simply contain a slice of this
+//! vec.
+//!
+//! This almost works. but there's two main issues:
+//! - compounds aren't length-prefixed, so we can't pre-allocate at the beginning of compounds for
+//! the rest of that compound
+//! - resizing a vec might move it in memory, invalidating all of our slices to it
+//!
+//! solving the first problem isn't that hard, since we can have a separate vec for every "depth"
+//! (so compounds in compounds don't share the same vec).
+//! to solve the second problem, i chose to implement a special data structure
+//! that relies on low-level allocations so we can guarantee that our allocations don't move in memory.
+
+use std::{
+    alloc::{self, Layout},
+    fmt,
+    ptr::NonNull,
+};
+
+use crate::Mutf8Str;
+
+use super::{NbtCompound, NbtList, NbtTag};
+
+const MIN_ALLOC_SIZE: usize = 1024;
+
+#[derive(Default)]
+pub struct TagAllocator<'a> {
+    // it's a vec because of the depth thing mentioned earlier, index in the vec = depth
+    named_tags: Vec<TagsAllocation<(&'a Mutf8Str, NbtTag<'a>)>>,
+    // we also have to keep track of old allocations so we can deallocate them later
+    previous_named_tags: Vec<Vec<TagsAllocation<(&'a Mutf8Str, NbtTag<'a>)>>>,
+
+    // so remember earlier when i said the depth thing is only necessary because compounds aren't
+    // length prefixed? ... well soooo i decided to make arrays store per-depth separately too to
+    // avoid exploits where an array with a big length is sent to force it to immediately allocate
+    // a lot
+    unnamed_list_tags: Vec<TagsAllocation<NbtList<'a>>>,
+    previous_unnamed_list_tags: Vec<Vec<TagsAllocation<NbtList<'a>>>>,
+
+    unnamed_compound_tags: Vec<TagsAllocation<NbtCompound<'a>>>,
+    previous_unnamed_compound_tags: Vec<Vec<TagsAllocation<NbtCompound<'a>>>>,
+}
+
+impl<'a> TagAllocator<'a> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn start_named_tags(
+        &mut self,
+        depth: usize,
+    ) -> ContiguousTagsAllocator<(&'a Mutf8Str, NbtTag<'a>)> {
+        start_allocating_tags_with_depth(depth, &mut self.named_tags, &mut self.previous_named_tags)
+    }
+    pub fn finish_named_tags(
+        &mut self,
+        alloc: ContiguousTagsAllocator<(&'a Mutf8Str, NbtTag<'a>)>,
+        depth: usize,
+    ) -> &'a [(&'a Mutf8Str, NbtTag)] {
+        finish_allocating_tags_with_depth(
+            alloc,
+            depth,
+            &mut self.named_tags,
+            &mut self.previous_named_tags,
+        )
+    }
+
+    pub fn start_unnamed_list_tags(
+        &mut self,
+        depth: usize,
+    ) -> ContiguousTagsAllocator<NbtList<'a>> {
+        start_allocating_tags_with_depth(
+            depth,
+            &mut self.unnamed_list_tags,
+            &mut self.previous_unnamed_list_tags,
+        )
+    }
+    pub fn finish_unnamed_list_tags(
+        &mut self,
+        alloc: ContiguousTagsAllocator<NbtList<'a>>,
+        depth: usize,
+    ) -> &'a [NbtList<'a>] {
+        finish_allocating_tags_with_depth(
+            alloc,
+            depth,
+            &mut self.unnamed_list_tags,
+            &mut self.previous_unnamed_list_tags,
+        )
+    }
+
+    pub fn start_unnamed_compound_tags(
+        &mut self,
+        depth: usize,
+    ) -> ContiguousTagsAllocator<NbtCompound<'a>> {
+        start_allocating_tags_with_depth(
+            depth,
+            &mut self.unnamed_compound_tags,
+            &mut self.previous_unnamed_compound_tags,
+        )
+    }
+    pub fn finish_unnamed_compound_tags(
+        &mut self,
+        alloc: ContiguousTagsAllocator<NbtCompound<'a>>,
+        depth: usize,
+    ) -> &'a [NbtCompound<'a>] {
+        finish_allocating_tags_with_depth(
+            alloc,
+            depth,
+            &mut self.unnamed_compound_tags,
+            &mut self.previous_unnamed_compound_tags,
+        )
+    }
+}
+impl Drop for TagAllocator<'_> {
+    fn drop(&mut self) {
+        self.named_tags
+            .iter_mut()
+            .for_each(TagsAllocation::deallocate);
+        self.previous_named_tags
+            .iter_mut()
+            .flatten()
+            .for_each(TagsAllocation::deallocate);
+
+        self.unnamed_list_tags
+            .iter_mut()
+            .for_each(TagsAllocation::deallocate);
+        self.previous_unnamed_list_tags
+            .iter_mut()
+            .flatten()
+            .for_each(TagsAllocation::deallocate);
+
+        self.unnamed_compound_tags
+            .iter_mut()
+            .for_each(TagsAllocation::deallocate);
+        self.previous_unnamed_compound_tags
+            .iter_mut()
+            .flatten()
+            .for_each(TagsAllocation::deallocate);
+    }
+}
+
+pub fn start_allocating_tags_with_depth<T>(
+    depth: usize,
+    tags: &mut Vec<TagsAllocation<T>>,
+    previous_allocs: &mut Vec<Vec<TagsAllocation<T>>>,
+) -> ContiguousTagsAllocator<T>
+where
+    T: Clone,
+{
+    // make sure we have enough space for this depth
+    // (also note that depth is reused for compounds and arrays so we might have to push
+    // more than once)
+    for _ in tags.len()..=depth {
+        tags.push(Default::default());
+        previous_allocs.push(Default::default());
+    }
+
+    let alloc = tags[depth].clone();
+
+    start_allocating_tags(alloc)
+}
+fn finish_allocating_tags_with_depth<'a, T>(
+    alloc: ContiguousTagsAllocator<T>,
+    depth: usize,
+    tags: &mut [TagsAllocation<T>],
+    previous_allocs: &mut [Vec<TagsAllocation<T>>],
+) -> &'a [T]
+where
+    T: Clone,
+{
+    finish_allocating_tags(alloc, &mut tags[depth], &mut previous_allocs[depth])
+}
+
+fn start_allocating_tags<T>(alloc: TagsAllocation<T>) -> ContiguousTagsAllocator<T> {
+    let is_new_allocation = alloc.cap == 0;
+    ContiguousTagsAllocator {
+        alloc,
+        is_new_allocation,
+        size: 0,
+    }
+}
+fn finish_allocating_tags<'a, T>(
+    alloc: ContiguousTagsAllocator<T>,
+    current_alloc: &mut TagsAllocation<T>,
+    previous_allocs: &mut Vec<TagsAllocation<T>>,
+) -> &'a [T] {
+    let slice = unsafe {
+        std::slice::from_raw_parts(
+            alloc
+                .alloc
+                .ptr
+                .as_ptr()
+                .add(alloc.alloc.len)
+                .sub(alloc.size),
+            alloc.size,
+        )
+    };
+
+    let previous_allocation_at_that_depth = std::mem::replace(current_alloc, alloc.alloc);
+    if alloc.is_new_allocation {
+        previous_allocs.push(previous_allocation_at_that_depth);
+    }
+
+    slice
+}
+
+#[derive(Clone)]
+pub struct TagsAllocation<T> {
+    ptr: NonNull<T>,
+    cap: usize,
+    len: usize,
+}
+impl<T> Default for TagsAllocation<T> {
+    fn default() -> Self {
+        Self {
+            ptr: NonNull::dangling(),
+            cap: 0,
+            len: 0,
+        }
+    }
+}
+impl<T> TagsAllocation<T> {
+    fn deallocate(&mut self) {
+        if self.cap == 0 {
+            return;
+        }
+
+        // call drop on the tags too
+        unsafe {
+            std::ptr::drop_in_place(std::slice::from_raw_parts_mut(
+                self.ptr.as_ptr().cast::<T>(),
+                self.len,
+            ));
+        }
+
+        unsafe {
+            alloc::dealloc(
+                self.ptr.as_ptr().cast(),
+                Layout::array::<T>(self.cap).unwrap(),
+            )
+        }
+    }
+}
+
+// this is created when we start allocating a compound tag
+pub struct ContiguousTagsAllocator<T> {
+    alloc: TagsAllocation<T>,
+    /// whether we created a new allocation for this compound (as opposed to reusing an existing
+    /// one).
+    /// this is used to determine whether we're allowed to deallocate it when growing, and whether
+    /// we should add this allocation to `all_allocations`
+    is_new_allocation: bool,
+    /// the size of this individual compound allocation. the size of the full allocation is in
+    /// `alloc.len`.
+    size: usize,
+}
+
+impl<T> ContiguousTagsAllocator<T> {
+    fn grow(&mut self) {
+        let new_cap = if self.is_new_allocation {
+            // this makes sure we don't allocate 0 bytes
+            std::cmp::max(self.alloc.cap * 2, MIN_ALLOC_SIZE)
+        } else {
+            // reuse the previous cap, since it's not unlikely that we'll have another compound
+            // with a similar
+            self.alloc.cap
+        };
+
+        let new_layout = Layout::array::<T>(new_cap).unwrap();
+
+        let new_ptr = if self.is_new_allocation && self.alloc.ptr != NonNull::dangling() {
+            let old_ptr = self.alloc.ptr.as_ptr();
+            let old_cap = self.alloc.cap;
+            let old_layout = Layout::array::<T>(old_cap).unwrap();
+            unsafe { alloc::realloc(old_ptr as *mut u8, old_layout, new_cap) }
+        } else {
+            self.is_new_allocation = true;
+            unsafe { alloc::alloc(new_layout) }
+        } as *mut T;
+
+        // copy the last `size` elements from the old allocation to the new one
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                self.alloc.ptr.as_ptr().sub(self.size),
+                new_ptr,
+                self.size,
+            )
+        };
+
+        self.alloc.ptr = NonNull::new(new_ptr).unwrap();
+        self.alloc.cap = new_cap;
+        self.alloc.len = self.size;
+    }
+
+    pub fn push(&mut self, value: T) {
+        // check if we need to reallocate
+        if self.alloc.len == self.alloc.cap {
+            self.grow();
+        }
+
+        // push the new tag
+        unsafe {
+            std::ptr::write(self.alloc.ptr.as_ptr().add(self.alloc.len), value);
+        }
+        self.alloc.len += 1;
+        self.size += 1;
+    }
+}
+
+impl<'a> fmt::Debug for TagAllocator<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TagAllocator").finish()
+    }
+}

--- a/simdnbt/src/borrow/tag_alloc.rs
+++ b/simdnbt/src/borrow/tag_alloc.rs
@@ -261,6 +261,7 @@ pub struct ContiguousTagsAllocator<T> {
 }
 
 impl<T> ContiguousTagsAllocator<T> {
+    #[inline(never)]
     fn grow(&mut self) {
         let new_cap = if self.is_new_allocation {
             // this makes sure we don't allocate 0 bytes
@@ -297,6 +298,7 @@ impl<T> ContiguousTagsAllocator<T> {
         self.alloc.len = self.size;
     }
 
+    #[inline]
     pub fn push(&mut self, value: T) {
         // check if we need to reallocate
         if self.alloc.len == self.alloc.cap {
@@ -305,7 +307,8 @@ impl<T> ContiguousTagsAllocator<T> {
 
         // push the new tag
         unsafe {
-            std::ptr::write(self.alloc.ptr.as_ptr().add(self.alloc.len), value);
+            let end = self.alloc.ptr.as_ptr().add(self.alloc.len);
+            std::ptr::write(end, value);
         }
         self.alloc.len += 1;
         self.size += 1;

--- a/simdnbt/src/error.rs
+++ b/simdnbt/src/error.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 use crate::common::MAX_DEPTH;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq)]
 pub enum Error {
     #[error("Invalid root type {0}")]
     InvalidRootType(u8),


### PR DESCRIPTION
This PR significantly optimizes simdnbt::borrow::Nbt::read by introducing three major optimizations:
- Reducing the number of small allocations by storing all tags contiguously in their own place in memory (see the comment in tag_alloc.rs for more details)
- Making NbtTag/NbtList two bytes smaller by replacing all the `Vec`s in it with slices and removing the #[repr(u8)] from NbtTag
- Inlining read_with_type

With these changes, complex_player.dat and level.dat are 88%-95% faster to decode on my machine.