### PR TITLE
Implement thin slices (scrapped)

### DIFF
--- a/simdnbt/src/lib.rs
+++ b/simdnbt/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![feature(portable_simd)]
 #![feature(array_chunks)]
+#![feature(ptr_metadata)]
 
 pub mod borrow;
 mod common;
@@ -9,6 +10,7 @@ mod mutf8;
 pub mod owned;
 pub mod raw_list;
 pub mod swap_endianness;
+mod thin_slices;
 mod traits;
 
 pub use error::{DeserializeError, Error};

--- a/simdnbt/src/mutf8.rs
+++ b/simdnbt/src/mutf8.rs
@@ -7,6 +7,8 @@ use std::{
     simd::prelude::*,
 };
 
+use crate::thin_slices::Slice16Bit;
+
 /// A M-UTF8 string slice. This is how strings are represented internally in NBT.
 #[derive(Eq, PartialEq)]
 pub struct Mutf8Str {
@@ -85,6 +87,11 @@ impl Mutf8Str {
     pub fn from_slice(slice: &[u8]) -> &Mutf8Str {
         // SAFETY: &[u8] and &Mutf8Str are the same layout.
         unsafe { mem::transmute::<&[u8], &Mutf8Str>(slice) }
+    }
+
+    #[inline]
+    pub fn from_slice_16bit(slice: Slice16Bit<[u8]>) -> Slice16Bit<Mutf8Str> {
+        Slice16Bit::new(slice.as_ptr(), slice.len())
     }
 
     // we can't implement FromStr on Cow<Mutf8Str>

--- a/simdnbt/src/owned/compound.rs
+++ b/simdnbt/src/owned/compound.rs
@@ -48,7 +48,7 @@ impl NbtCompound {
             if tag_type == END_ID {
                 break;
             }
-            let tag_name = read_string(data)?.to_owned();
+            let tag_name: Mutf8String = (*read_string(data)?).to_owned();
             let tag = NbtTag::read_with_type(data, tag_type, depth)?;
 
             tags_buffer[tags_buffer_len] = MaybeUninit::new((tag_name, tag));

--- a/simdnbt/src/owned/list.rs
+++ b/simdnbt/src/owned/list.rs
@@ -47,7 +47,7 @@ impl NbtList {
                 data.set_position(data.position() + 4);
                 NbtList::Empty
             }
-            BYTE_ID => NbtList::Byte(read_i8_array(data)?.to_owned()),
+            BYTE_ID => NbtList::Byte(read_i8_array(data)?.to_vec()),
             SHORT_ID => NbtList::Short(swap_endianness(read_with_u32_length(data, 2)?)),
             INT_ID => NbtList::Int(swap_endianness(read_with_u32_length(data, 4)?)),
             LONG_ID => NbtList::Long(swap_endianness(read_with_u32_length(data, 8)?)),
@@ -67,7 +67,7 @@ impl NbtList {
                 // arbitrary number to prevent big allocations
                 let mut strings = Vec::with_capacity(length.min(128) as usize);
                 for _ in 0..length {
-                    strings.push(read_string(data)?.to_owned())
+                    strings.push((*read_string(data)?).to_owned())
                 }
                 strings
             }),
@@ -135,19 +135,23 @@ impl NbtList {
                 write_with_u32_length(data, 1, slice_i8_into_u8(bytes));
             }
             NbtList::Short(shorts) => {
-                write_with_u32_length(data, 2, &slice_into_u8_big_endian(shorts));
+                write_with_u32_length(data, 2, &slice_into_u8_big_endian(shorts.as_slice().into()));
             }
             NbtList::Int(ints) => {
-                write_with_u32_length(data, 4, &slice_into_u8_big_endian(ints));
+                write_with_u32_length(data, 4, &slice_into_u8_big_endian(ints.as_slice().into()));
             }
             NbtList::Long(longs) => {
-                write_with_u32_length(data, 8, &slice_into_u8_big_endian(longs));
+                write_with_u32_length(data, 8, &slice_into_u8_big_endian(longs.as_slice().into()));
             }
             NbtList::Float(floats) => {
-                write_with_u32_length(data, 4, &slice_into_u8_big_endian(floats));
+                write_with_u32_length(data, 4, &slice_into_u8_big_endian(floats.as_slice().into()));
             }
             NbtList::Double(doubles) => {
-                write_with_u32_length(data, 8, &slice_into_u8_big_endian(doubles));
+                write_with_u32_length(
+                    data,
+                    8,
+                    &slice_into_u8_big_endian(doubles.as_slice().into()),
+                );
             }
             NbtList::ByteArray(byte_arrays) => {
                 write_u32(data, byte_arrays.len() as u32);
@@ -173,13 +177,21 @@ impl NbtList {
             NbtList::IntArray(int_arrays) => {
                 write_u32(data, int_arrays.len() as u32);
                 for array in int_arrays {
-                    write_with_u32_length(data, 4, &slice_into_u8_big_endian(array));
+                    write_with_u32_length(
+                        data,
+                        4,
+                        &slice_into_u8_big_endian(array.as_slice().into()),
+                    );
                 }
             }
             NbtList::LongArray(long_arrays) => {
                 write_u32(data, long_arrays.len() as u32);
                 for array in long_arrays {
-                    write_with_u32_length(data, 8, &slice_into_u8_big_endian(array));
+                    write_with_u32_length(
+                        data,
+                        8,
+                        &slice_into_u8_big_endian(array.as_slice().into()),
+                    );
                 }
             }
         }

--- a/simdnbt/src/owned/mod.rs
+++ b/simdnbt/src/owned/mod.rs
@@ -48,7 +48,7 @@ impl Nbt {
         if root_type != COMPOUND_ID {
             return Err(Error::InvalidRootType(root_type));
         }
-        let name = read_string(data)?.to_owned();
+        let name = (*read_string(data)?).to_owned();
         let tag = NbtCompound::read_with_depth(data, 0)?;
 
         Ok(Nbt::Some(BaseNbt { name, tag }))
@@ -247,8 +247,8 @@ impl NbtTag {
             DOUBLE_ID => Ok(NbtTag::Double(
                 data.read_f64::<BE>().map_err(|_| Error::UnexpectedEof)?,
             )),
-            BYTE_ARRAY_ID => Ok(NbtTag::ByteArray(read_with_u32_length(data, 1)?.to_owned())),
-            STRING_ID => Ok(NbtTag::String(read_string(data)?.to_owned())),
+            BYTE_ARRAY_ID => Ok(NbtTag::ByteArray(read_with_u32_length(data, 1)?.to_vec())),
+            STRING_ID => Ok(NbtTag::String((*read_string(data)?).to_owned())),
             LIST_ID => Ok(NbtTag::List(NbtList::read(data, depth + 1)?)),
             COMPOUND_ID => Ok(NbtTag::Compound(NbtCompound::read_with_depth(
                 data,
@@ -319,13 +319,13 @@ impl NbtTag {
                 unsafe {
                     unchecked_extend(data, &int_array.len().to_be_bytes());
                 }
-                data.extend_from_slice(&slice_into_u8_big_endian(int_array));
+                data.extend_from_slice(&slice_into_u8_big_endian(int_array.as_slice().into()));
             }
             NbtTag::LongArray(long_array) => {
                 unsafe {
                     unchecked_extend(data, &long_array.len().to_be_bytes());
                 }
-                data.extend_from_slice(&slice_into_u8_big_endian(long_array));
+                data.extend_from_slice(&slice_into_u8_big_endian(long_array.as_slice().into()));
             }
         }
     }

--- a/simdnbt/src/raw_list.rs
+++ b/simdnbt/src/raw_list.rs
@@ -1,24 +1,35 @@
-use std::{marker::PhantomData, mem};
+use std::{
+    fmt::{self, Debug},
+    marker::PhantomData,
+    mem,
+};
 
-use crate::swap_endianness::{swap_endianness, swap_endianness_as_u8, SwappableNumber};
+use crate::{
+    swap_endianness::{swap_endianness, swap_endianness_as_u8, SwappableNumber},
+    thin_slices::Slice32Bit,
+};
 
 /// A list of numbers that's kept as big-endian in memory.
 
-#[derive(Debug, PartialEq, Clone)]
+// #[derive(Debug, PartialEq, Clone)]
+#[repr(transparent)]
 pub struct RawList<'a, T> {
-    data: &'a [u8],
+    data: Slice32Bit<'a, [u8]>,
     _marker: PhantomData<T>,
 }
 impl<'a, T> RawList<'a, T> {
-    pub fn new(data: &'a [u8]) -> Self {
+    pub fn new(data: Slice32Bit<'a, [u8]>) -> Self {
         Self {
             data,
             _marker: PhantomData,
         }
     }
+    pub fn new_from_slice(data: &'a [u8]) -> Self {
+        Self::new(Slice32Bit::new(data.as_ptr(), data.len() as u32))
+    }
 
     pub fn len(&self) -> usize {
-        self.data.len() / mem::size_of::<T>()
+        (self.data.len() / mem::size_of::<T>() as u32) as usize
     }
 
     pub fn is_empty(&self) -> bool {
@@ -39,7 +50,7 @@ impl<T: SwappableNumber> RawList<'_, T> {
     }
 
     pub fn as_big_endian(&self) -> &[u8] {
-        self.data
+        &self.data
     }
 }
 
@@ -63,5 +74,27 @@ where
 
     fn into_iter(self) -> Self::IntoIter {
         self.to_vec().into_iter()
+    }
+}
+
+impl<T> Debug for RawList<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.data.fmt(f)
+    }
+}
+impl<T> PartialEq for RawList<'_, T>
+where
+    T: PartialEq + Copy + SwappableNumber,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.to_vec() == other.to_vec()
+    }
+}
+impl<T> Clone for RawList<'_, T> {
+    fn clone(&self) -> Self {
+        Self {
+            data: self.data.clone(),
+            _marker: PhantomData,
+        }
     }
 }

--- a/simdnbt/src/thin_slices.rs
+++ b/simdnbt/src/thin_slices.rs
@@ -1,0 +1,220 @@
+use std::{
+    fmt::{self, Debug, Pointer},
+    marker::PhantomData,
+    ops::Deref,
+    ptr::Pointee,
+};
+
+#[repr(packed(2))]
+pub struct Slice16Bit<'a, T>
+where
+    T: ?Sized + Pointee,
+    <T as Pointee>::Metadata: From<usize>,
+{
+    ptr: *const u8,
+    len: u16,
+    _marker: PhantomData<&'a T>,
+}
+
+#[repr(packed(4))]
+pub struct Slice32Bit<'a, T>
+where
+    T: ?Sized + Pointee,
+    <T as Pointee>::Metadata: From<usize>,
+{
+    ptr: *const u8,
+    len: u32,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T> Slice32Bit<'a, T>
+where
+    T: ?Sized + Pointee,
+    <T as Pointee>::Metadata: From<usize>,
+{
+    pub fn new(ptr: *const u8, len: u32) -> Self {
+        Self {
+            ptr,
+            len,
+            _marker: PhantomData,
+        }
+    }
+    pub fn len(&self) -> u32 {
+        self.len
+    }
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+    pub fn as_ptr(&self) -> *const u8 {
+        self.ptr
+    }
+}
+impl<T> Deref for Slice32Bit<'_, T>
+where
+    T: ?Sized + Pointee,
+    <T as Pointee>::Metadata: From<usize>,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        // self.ptr.with_metadata_of(&self.len).as_ptr()
+        let p = std::ptr::from_raw_parts(self.ptr as *const (), (self.len as usize).into());
+        unsafe { &*(p as *const T) }
+    }
+}
+impl<T> Debug for Slice32Bit<'_, T>
+where
+    T: ?Sized + Pointee,
+    <T as Pointee>::Metadata: From<usize>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (&**self).fmt(f)
+    }
+}
+impl<T> PartialEq for Slice32Bit<'_, T>
+where
+    T: PartialEq,
+    T: ?Sized + Pointee,
+    <T as Pointee>::Metadata: From<usize>,
+{
+    fn eq(&self, other: &Self) -> bool {
+        (&**self).eq(&**other)
+    }
+}
+impl<T> Clone for Slice32Bit<'_, T>
+where
+    T: ?Sized + Pointee,
+    <T as Pointee>::Metadata: From<usize>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            ptr: self.ptr,
+            len: self.len,
+            _marker: PhantomData,
+        }
+    }
+}
+impl<T> Copy for Slice32Bit<'_, T>
+where
+    T: ?Sized + Pointee,
+    <T as Pointee>::Metadata: From<usize>,
+{
+}
+impl<T> Default for Slice32Bit<'_, T>
+where
+    T: ?Sized + Pointee,
+    <T as Pointee>::Metadata: From<usize>,
+{
+    fn default() -> Self {
+        Self {
+            ptr: std::ptr::null(),
+            len: 0,
+            _marker: PhantomData,
+        }
+    }
+}
+impl<'a, T> From<&'a [T]> for Slice32Bit<'a, [T]> {
+    fn from(slice: &'a [T]) -> Self {
+        Self {
+            ptr: slice.as_ptr() as *const u8,
+            len: slice.len() as u32,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, T> Slice16Bit<'a, T>
+where
+    T: ?Sized + Pointee,
+    <T as Pointee>::Metadata: From<usize>,
+{
+    pub fn new(ptr: *const u8, len: u16) -> Self {
+        Self {
+            ptr,
+            len,
+            _marker: PhantomData,
+        }
+    }
+    pub fn len(&self) -> u16 {
+        self.len
+    }
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+    pub fn as_ptr(&self) -> *const u8 {
+        self.ptr
+    }
+}
+impl<T> Deref for Slice16Bit<'_, T>
+where
+    T: ?Sized + Pointee,
+    <T as Pointee>::Metadata: From<usize>,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        // self.ptr.with_metadata_of(&self.len).as_ptr()
+        let p = std::ptr::from_raw_parts(self.ptr as *const (), (self.len as usize).into());
+        unsafe { &*(p as *const T) }
+    }
+}
+impl<T> Debug for Slice16Bit<'_, T>
+where
+    T: ?Sized + Pointee,
+    <T as Pointee>::Metadata: From<usize>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (&**self).fmt(f)
+    }
+}
+impl<T> PartialEq for Slice16Bit<'_, T>
+where
+    T: PartialEq,
+    T: ?Sized + Pointee,
+    <T as Pointee>::Metadata: From<usize>,
+{
+    fn eq(&self, other: &Self) -> bool {
+        (&**self).eq(&**other)
+    }
+}
+impl<T> Clone for Slice16Bit<'_, T>
+where
+    T: ?Sized + Pointee,
+    <T as Pointee>::Metadata: From<usize>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            ptr: self.ptr,
+            len: self.len,
+            _marker: PhantomData,
+        }
+    }
+}
+impl<T> Copy for Slice16Bit<'_, T>
+where
+    T: ?Sized + Pointee,
+    <T as Pointee>::Metadata: From<usize>,
+{
+}
+impl<T> Default for Slice16Bit<'_, T>
+where
+    T: ?Sized + Pointee,
+    <T as Pointee>::Metadata: From<usize>,
+{
+    fn default() -> Self {
+        Self {
+            ptr: std::ptr::null(),
+            len: 0,
+            _marker: PhantomData,
+        }
+    }
+}
+impl<'a, T> From<&'a [T]> for Slice16Bit<'a, [T]> {
+    fn from(slice: &'a [T]) -> Self {
+        Self {
+            ptr: slice.as_ptr() as *const u8,
+            len: slice.len() as u16,
+            _marker: PhantomData,
+        }
+    }
+}

--- a/simdnbt/src/traits.rs
+++ b/simdnbt/src/traits.rs
@@ -39,7 +39,7 @@ pub trait ToNbtTag: Sized {
 
 impl<K: Display + FromStr + Eq + Hash, V: FromNbtTag> Deserialize for HashMap<K, V> {
     fn from_compound(compound: &crate::borrow::NbtCompound) -> Result<Self, DeserializeError> {
-        let mut hashmap = HashMap::with_capacity(compound.len());
+        let mut hashmap = HashMap::with_capacity(compound.len() as usize);
 
         for (k, v) in compound.iter() {
             let k_str = k.to_str();


### PR DESCRIPTION
This was an experiment to see how performance would be affected if I optimized slices to be thinner, so NbtTag would be 16 bits (as opposed to 24). Unfortunately, it did make performance worse (probably because of conversions from u16/u32 to usize), and it significantly hurt ergonomics (since some APIs return Slice16Bit/Slice32Bit types instead of just normal slices, so they're harder to work with).

This PR was made to archive this attempt at an optimization, it will not be merged.