### PR TITLE
Made Mutf8String public to the consumer

### DIFF
--- a/simdnbt/src/lib.rs
+++ b/simdnbt/src/lib.rs
@@ -20,7 +20,7 @@ pub mod swap_endianness;
 mod traits;
 
 pub use error::{DeserializeError, Error};
-pub use mutf8::Mutf8Str;
+pub use mutf8::{Mutf8Str, Mutf8String};
 pub use simdnbt_derive::*;
 pub use traits::{Deserialize, FromNbtTag, Serialize, ToNbtTag};
 


### PR DESCRIPTION
Currently only `Mutf8Str` is public outside the crate itself but the consumer can still get the owned `Mutf8String` via related functions in `Mutf8Str`. But is unable to use the actual type themself