### PR TITLE
Implement DerefMut for owned::BaseNbt

### DIFF
--- a/simdnbt/src/owned/mod.rs
+++ b/simdnbt/src/owned/mod.rs
@@ -6,7 +6,10 @@ mod list;
 #[cfg(feature = "serde")]
 mod serde_impl;
 
-use std::{io::Cursor, ops::Deref};
+use std::{
+    io::Cursor,
+    ops::{Deref, DerefMut},
+};
 
 pub use self::{compound::NbtCompound, list::NbtList};
 use crate::{
@@ -241,6 +244,12 @@ impl Deref for BaseNbt {
 
     fn deref(&self) -> &Self::Target {
         &self.tag
+    }
+}
+
+impl DerefMut for BaseNbt {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.tag
     }
 }
 


### PR DESCRIPTION
Pretty much what the title says. The owned BaseNbt already implements Deref<Target=NbtCompound>, but not DerefMut and doesn't provide a way to mutably access it's tag field from a mutable reference.